### PR TITLE
Fix handling empty mentions while predicting. 

### DIFF
--- a/tner/model_prediction.py
+++ b/tner/model_prediction.py
@@ -91,6 +91,7 @@ class TransformersNER:
             _entities = []
             for tag, (start, end) in tag_lists:
                 mention = self.transforms.tokenizer.decode(e[start:end], skip_special_tokens=True)
+                if not len(mention.strip()): continue
                 start_char = len(self.transforms.tokenizer.decode(e[:start], skip_special_tokens=True))
                 if sentence[start_char] == ' ':
                     start_char += 1


### PR DESCRIPTION
Handling empty mentions are throwing following error:

```
File "...../lib/python3.7/site-packages/tner/model_prediction.py", line 95, in predict
    if sentence[start_char] == ' ':
IndexError: string index out of range
```

For example, the following sentence creates empty mentions: 

'The 1901 Villanova Wildcats football team represented the Villanova University during the 1901 college football season.'

[Colab ](https://colab.research.google.com/drive/1mQ_kQWeZkVs6LgV0KawHxHckFraYcFfO) prediction example environment is sufficient for recreating the issue with the given example.

Solution: Ignore empty mentions, and with loop continuation. 