### PR TITLE
Remove dep to allennlp (deprecated) in favor of allennlp-light

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     test_suite='tests',
     install_requires=[
         'torch',
-        'allennlp>=2.0.0',
+        'allennlp-light',
         'transformers',
         'sentencepiece',
         'seqeval',

--- a/tner/ner_model.py
+++ b/tner/ner_model.py
@@ -9,12 +9,8 @@ from packaging.version import parse
 import torch
 
 # For CRF Layer
-from allennlp import __version__
-from allennlp.modules import ConditionalRandomField
-if parse("2.10.0") > parse(__version__):
-    from allennlp.modules.conditional_random_field import allowed_transitions
-else:
-    from allennlp.modules.conditional_random_field.conditional_random_field import allowed_transitions
+from allennlp_light.modules import ConditionalRandomField
+from allennlp_light.modules.conditional_random_field.conditional_random_field import allowed_transitions
 
 from .get_dataset import get_dataset
 from .util import pickle_save, pickle_load, span_f1, decode_ner_tags, Dataset, load_hf


### PR DESCRIPTION
allennlp seem to be deprecated. I ran into issues installing it, so I removed the dependency in favor of allennlp-light (as advised on their github readme)